### PR TITLE
Patch 1

### DIFF
--- a/kernel/include/common.h
+++ b/kernel/include/common.h
@@ -8,4 +8,11 @@ struct task {};
 struct spinlock {};
 struct semaphore {};
 
+#define Assert(cond) \
+    do{ \
+        if(!(cond)){ \
+            printf("%s:%d Assertion %s failed!\n",__FILE__,__LINE__, #cond); \
+            _halt(1); \
+        } \
+    }while(0)
 #endif

--- a/kernel/src/devices/input/input.c
+++ b/kernel/src/devices/input/input.c
@@ -96,7 +96,10 @@ void input_task(void *args) {
   }
 }
 
+devops_t input_ops;
+
 static int input_init(device_t *dev) {
+  Assert(dev->ops==&input_ops);
   input_t *in = dev->ptr;
   in->events = pmm->alloc(sizeof(in->events[0]) * NEVENTS);
   in->front = in->rear = 0;
@@ -109,6 +112,7 @@ static int input_init(device_t *dev) {
 }
 
 static ssize_t input_read(device_t *dev, off_t offset, void *buf, size_t count) {
+  Assert(dev->ops==&input_ops);
   struct input_event ev = pop_event(dev->ptr);
   if (count >= sizeof(ev)) {
     memcpy(buf, &ev, sizeof(ev));
@@ -119,6 +123,7 @@ static ssize_t input_read(device_t *dev, off_t offset, void *buf, size_t count) 
 }
 
 static ssize_t input_write(device_t *dev, off_t offset, const void *buf, size_t count) {
+  Assert(dev->ops==&input_ops);
   return 0;
 }
 

--- a/kernel/src/devices/ramdisk/ramdisk.c
+++ b/kernel/src/devices/ramdisk/ramdisk.c
@@ -2,7 +2,10 @@
 
 extern char initrd_start, initrd_end;
 
+devops_t rd_ops;
+
 int rd_init(device_t *dev) {
+  Assert(dev->ops==&rd_ops);
   rd_t *rd = dev->ptr;
   if (dev->id == 1) {
     rd->start = &initrd_start;
@@ -16,12 +19,14 @@ int rd_init(device_t *dev) {
 }
 
 ssize_t rd_read(device_t *dev, off_t offset, void *buf, size_t count) {
+  Assert(dev->ops==&rd_ops);
   rd_t *rd = dev->ptr;
   memcpy(buf, ((char *)rd->start) + offset, count);
   return count;
 }
 
 ssize_t rd_write(device_t *dev, off_t offset, const void *buf, size_t count) {
+  Assert(dev->ops==&rd_ops);
   rd_t *rd = dev->ptr;
   memcpy(((char *)rd->start) + offset, buf, count);
   return count;

--- a/kernel/src/devices/tty/tty.c
+++ b/kernel/src/devices/tty/tty.c
@@ -163,7 +163,7 @@ static void tty_putc(tty_t *tty, char ch) {
 devops_t tty_ops;
 
 int tty_init(device_t *dev) {
-  Assert(dev->ops==tty_ops);
+  Assert(dev->ops==&tty_ops);
   tty_t *tty = dev->ptr;
   tty->fbdev = dev_lookup("fb");
   fb_t *fb = tty->fbdev->ptr;
@@ -188,7 +188,7 @@ int tty_init(device_t *dev) {
 }
 
 ssize_t tty_read(device_t *dev, off_t offset, void *buf, size_t count) {
-  Assert(dev->ops==tty_ops);
+  Assert(dev->ops==&tty_ops);
   tty_t *tty = dev->ptr;
   kmt->sem_wait(&tty->cooked);
   kmt->sem_wait(&tty->lock);
@@ -210,7 +210,7 @@ ssize_t tty_read(device_t *dev, off_t offset, void *buf, size_t count) {
 }
 
 ssize_t tty_write(device_t *dev, off_t offset, const void *buf, size_t count) {
-  Assert(dev->ops==tty_ops);
+  Assert(dev->ops==&tty_ops);
   tty_t *tty = dev->ptr;
   kmt->sem_wait(&tty->lock);
   for (size_t i = 0; i < count; i++) {

--- a/kernel/src/devices/tty/tty.c
+++ b/kernel/src/devices/tty/tty.c
@@ -160,7 +160,10 @@ static void tty_putc(tty_t *tty, char ch) {
   }
 }
 
+devops_t tty_ops;
+
 int tty_init(device_t *dev) {
+  Assert(dev->ops==tty_ops);
   tty_t *tty = dev->ptr;
   tty->fbdev = dev_lookup("fb");
   fb_t *fb = tty->fbdev->ptr;
@@ -185,6 +188,7 @@ int tty_init(device_t *dev) {
 }
 
 ssize_t tty_read(device_t *dev, off_t offset, void *buf, size_t count) {
+  Assert(dev->ops==tty_ops);
   tty_t *tty = dev->ptr;
   kmt->sem_wait(&tty->cooked);
   kmt->sem_wait(&tty->lock);
@@ -206,6 +210,7 @@ ssize_t tty_read(device_t *dev, off_t offset, void *buf, size_t count) {
 }
 
 ssize_t tty_write(device_t *dev, off_t offset, const void *buf, size_t count) {
+  Assert(dev->ops==tty_ops);
   tty_t *tty = dev->ptr;
   kmt->sem_wait(&tty->lock);
   for (size_t i = 0; i < count; i++) {

--- a/kernel/src/devices/video/video.c
+++ b/kernel/src/devices/video/video.c
@@ -5,6 +5,7 @@
 
 static sem_t fb_sem;
 extern uint8_t TERM_FONT[];
+devops_t fb_ops;
 
 static void texture_fill(struct texture *tx, int top, uint8_t *bits, uint32_t fg, uint32_t bg) {
   uint32_t *px = tx->pixels;
@@ -23,6 +24,7 @@ static void font_load(fb_t *fb, uint8_t *font) {
 }
 
 int fb_init(device_t *dev) {
+  Assert(dev->ops==fb_ops);
   fb_t *fb = dev->ptr;
   fb->info = pmm->alloc(sizeof(struct display_info));
   fb->textures = pmm->alloc(sizeof(struct texture) * NTEXTURE);
@@ -41,6 +43,7 @@ int fb_init(device_t *dev) {
 }
 
 ssize_t fb_read(device_t *dev, off_t offset, void *buf, size_t count) {
+  Assert(dev->ops==fb_ops);
   fb_t *fb = dev->ptr;
   if (offset != 0) return 0;
   if (count != sizeof(struct display_info)) return 0;
@@ -49,6 +52,7 @@ ssize_t fb_read(device_t *dev, off_t offset, void *buf, size_t count) {
 }
 
 ssize_t fb_write(device_t *dev, off_t offset, const void *buf, size_t count) {
+  Assert(dev->ops==fb_ops);
   fb_t *fb = dev->ptr;
   kmt->sem_wait(&fb_sem);
   if (offset == 0) {

--- a/kernel/src/devices/video/video.c
+++ b/kernel/src/devices/video/video.c
@@ -24,7 +24,7 @@ static void font_load(fb_t *fb, uint8_t *font) {
 }
 
 int fb_init(device_t *dev) {
-  Assert(dev->ops==fb_ops);
+  Assert(dev->ops==&fb_ops);
   fb_t *fb = dev->ptr;
   fb->info = pmm->alloc(sizeof(struct display_info));
   fb->textures = pmm->alloc(sizeof(struct texture) * NTEXTURE);
@@ -43,7 +43,7 @@ int fb_init(device_t *dev) {
 }
 
 ssize_t fb_read(device_t *dev, off_t offset, void *buf, size_t count) {
-  Assert(dev->ops==fb_ops);
+  Assert(dev->ops==&fb_ops);
   fb_t *fb = dev->ptr;
   if (offset != 0) return 0;
   if (count != sizeof(struct display_info)) return 0;
@@ -52,7 +52,7 @@ ssize_t fb_read(device_t *dev, off_t offset, void *buf, size_t count) {
 }
 
 ssize_t fb_write(device_t *dev, off_t offset, const void *buf, size_t count) {
-  Assert(dev->ops==fb_ops);
+  Assert(dev->ops==&fb_ops);
   fb_t *fb = dev->ptr;
   kmt->sem_wait(&fb_sem);
   if (offset == 0) {


### PR DESCRIPTION
Add a **dynamic** security check to "member functions" of devices.
It will check whether dev->ops equals to the device it desires.
If assertion fails, it means you pass a wrong type of device.